### PR TITLE
Heroku Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repo will contain all of the backend work",
   "main": "index.js",
   "scripts": {
-    "server": "nodemon index.js",
+    "server": "node index.js",
     "test": "cross-env NODE_ENV=testing jest --watch --verbose --runInBand",
     "start": "nodemon index.js",
     "docs": "apidoc -f .js -i ./ -e node_modules -o ./docs"


### PR DESCRIPTION
caused Heroku error 

```
2020-01-06T22:17:33.950030+00:00 app[web.1]: npm ERR! file sh
2020-01-06T22:17:33.950429+00:00 app[web.1]: npm ERR! errno ENOENT
2020-01-06T22:17:33.951799+00:00 app[web.1]: npm ERR! salty-comments-BackEnd@1.0.0 start: `nodemon index.js`
2020-01-06T22:17:33.951994+00:00 app[web.1]: npm ERR! spawn ENOENT
2020-01-06T22:17:33.952199+00:00 app[web.1]: npm ERR! 
2020-01-06T22:17:33.952386+00:00 app[web.1]: npm ERR! Failed at the salty-comments-BackEnd@1.0.0 start script.
2020-01-06T22:17:33.952591+00:00 app[web.1]: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
2020-01-06T22:17:33.958635+00:00 app[web.1]: 
2020-01-06T22:17:33.958812+00:00 app[web.1]: npm ERR! A complete log of this run can be found in:
2020-01-06T22:17:33.958942+00:00 app[web.1]: npm ERR!     /app/.npm/_logs/2020-01-06T22_17_33_953Z-debug.log
```